### PR TITLE
Add full service_type for Robot Shop deployment

### DIFF
--- a/ria-demo/defaults/main.yml
+++ b/ria-demo/defaults/main.yml
@@ -22,7 +22,7 @@ terraform_pkg_url: "https://releases.hashicorp.com/terraform/{{ __terraform_vers
 
 # Web App
 app_name: "robotshop" # robotshop, qotd, flightmonitor
-service_type: "frontend" # frontend / backend
+service_type: "frontend" # frontend / backend / full
 app_namespace: "super-automation-demo"
 registry_pwd: ""
 

--- a/ria-demo/tasks/setup_deploy_robot_shop.yaml
+++ b/ria-demo/tasks/setup_deploy_robot_shop.yaml
@@ -129,3 +129,85 @@
         YAML
       environment:
         KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+
+
+
+- name: Full Setup
+  when: service_type == 'full'
+  block:
+    - name: Install Robot Shop (full) with Helm
+      ansible.builtin.shell: |
+        helm upgrade --install robot-shop {{ robotshop_clone_dir }}/K8s/helm \
+          -n {{ app_namespace }} --create-namespace \
+          --set eum.key={{ instana_eum_key }} \
+          --set eum.url=https://{{ instana_endpoint_host }} \
+          --set nodeport=true --set openshift=false
+      environment:
+        KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+
+    - name: Create Ingress
+      ansible.builtin.shell: |
+        kubectl apply -n {{ app_namespace }} -f - <<EOF
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          name: robotshop-web-ingress
+          namespace: {{ app_namespace }}
+        spec:
+          # k3s nutzt Traefik; falls keine Default-IngressClass gesetzt ist, explizit angeben:
+          ingressClassName: traefik
+          rules:
+            - http:
+                paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: web
+                        port:
+                          number: 8080
+        EOF
+      environment:
+        KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+
+    - name: Deploy Load Generator
+      ansible.builtin.shell: |
+        kubectl apply -n {{ app_namespace }} -f - <<EOF
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: load
+          labels:
+            service: load
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              service: load
+          template:
+            metadata:
+              labels:
+                service: load
+            spec:
+              containers:
+              - name: load
+                env:
+                  - name: HOST
+                    value: "http://web:8080/"
+                  - name: NUM_CLIENTS
+                    value: "15"
+                  - name: SILENT
+                    value: "1"
+                  - name: ERROR
+                    value: "1"
+                image: robotshop/rs-load:latest
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 200Mi
+                  requests:
+                    cpu: 100m
+                    memory: 100Mi
+        EOF
+      environment:
+        KUBECONFIG: /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
Adds a "Full Setup" block to setup_deploy_robot_shop.yaml that installs the complete Robot Shop Helm chart (all components) in one namespace without the frontend/backend node-affinity split, plus ingress and load generator, when service_type is set to 'full'.